### PR TITLE
Decoupling sendgrid template id from Kafka topic 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,7 @@ jobs:
       - setup_remote_docker
       - run: *install_dependency
       - run: *install_deploysuite
-      - run:
-          name: give permission
-          command: chmod -R 777 root/project/
-      - restore_cache: *restore_cache_settings_for_build
+    #  - restore_cache: *restore_cache_settings_for_build
       - run: *run_build
       - save_cache: *save_cache_settings
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,10 @@ install_deploysuite: &install_deploysuite
             cp ./../buildscript/awsconfiguration.sh .
             
 restore_cache_settings_for_build: &restore_cache_settings_for_build
-  key: docker-tc-email-service-{{ checksum "package-lock.json" }}
+  key: circleci-tc-email-service-{{ checksum "package-lock.json" }}
 
 save_cache_settings: &save_cache_settings
-  key: docker-tc-email-service-{{ checksum "package-lock.json" }}
+  key: circleci-tc-email-service-{{ checksum "package-lock.json" }}
   paths:
     - node_modules
 
@@ -40,7 +40,7 @@ jobs:
       - setup_remote_docker
       - run: *install_dependency
       - run: *install_deploysuite
-    #  - restore_cache: *restore_cache_settings_for_build
+      - restore_cache: *restore_cache_settings_for_build
       - run: *run_build
       - save_cache: *save_cache_settings
       - deploy:

--- a/config/default.js
+++ b/config/default.js
@@ -21,7 +21,10 @@ module.exports = {
 
   VALID_ISSUERS: process.env.VALID_ISSUERS,
   KAFKA_URL: process.env.KAFKA_URL,
-  KAFKA_MAXBYTES: process.env.MAXBYTES || 2097152 /** 2MB /*,
+
+  // max bytes 2MB
+  KAFKA_MAXBYTES: process.env.MAXBYTES || 2097152,
+
   KAFKA_GROUP_ID: process.env.KAFKA_GROUP_ID,
   KAFKA_CLIENT_CERT: process.env.KAFKA_CLIENT_CERT ? process.env.KAFKA_CLIENT_CERT.replace('\\n', '\n') : null,
   KAFKA_CLIENT_CERT_KEY: process.env.KAFKA_CLIENT_CERT_KEY ?

--- a/config/default.js
+++ b/config/default.js
@@ -21,6 +21,7 @@ module.exports = {
 
   VALID_ISSUERS: process.env.VALID_ISSUERS,
   KAFKA_URL: process.env.KAFKA_URL,
+  KAFKA_MAXBYTES: process.env.MAXBYTES || 2097152 /** 2MB /*,
   KAFKA_GROUP_ID: process.env.KAFKA_GROUP_ID,
   KAFKA_CLIENT_CERT: process.env.KAFKA_CLIENT_CERT ? process.env.KAFKA_CLIENT_CERT.replace('\\n', '\n') : null,
   KAFKA_CLIENT_CERT_KEY: process.env.KAFKA_CLIENT_CERT_KEY ?

--- a/connect/connectEmailServer.js
+++ b/connect/connectEmailServer.js
@@ -9,6 +9,7 @@ const _ = require('lodash');
 const config = require('config');
 const emailServer = require('../index');
 const service = require('./service');
+const logger = require('../src/common/logger');
 
 // set configuration for the server, see ../config/default.js for available config parameters
 // setConfig should be called before initDatabase and start functions
@@ -26,11 +27,16 @@ const handler = (topic, message, callback) => {
     return callback(null, { success: false, error: `Template not found for topic ${topic}` });
   }
 
-  service.sendEmail(templateId, message).then(() => {
-    callback(null, { success: true });
-  }).catch((err) => {
-    callback(null, { success: false, error: err });
-  });
+  try {
+    service.sendEmail(templateId, message).then(() => {
+      callback(null, { success: true });
+    }).catch((err) => {
+      callback(null, { success: false, error: err });
+    });
+  } catch (error) {
+    logger.error('Unknown Error: ', error);
+  }
+
 };
 
 // init all events

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "@sendgrid/client": "6.3.0",
-    "@sendgrid/mail": "6.3.0",
+    "@sendgrid/mail": "6.3.1",
+    "@sendgrid/helpers": "6.3.0",
     "bluebird": "^3.5.1",
     "body-parser": "^1.15.2",
     "co": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "mocha": "^5.0.0"
   },
   "dependencies": {
-    "@sendgrid/client": "6.3.1",
-    "@sendgrid/mail": "6.3.1",
+    "@sendgrid/client": "6.3.0",
+    "@sendgrid/mail": "6.3.0",
     "bluebird": "^3.5.1",
     "body-parser": "^1.15.2",
     "co": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "mocha": "^5.0.0"
   },
   "dependencies": {
-    "@sendgrid/client": "^6.3.0",
-    "@sendgrid/mail": "^6.3.0",
+    "@sendgrid/client": "6.3.1",
+    "@sendgrid/mail": "6.3.1",
     "bluebird": "^3.5.1",
     "body-parser": "^1.15.2",
     "co": "^4.6.0",

--- a/src/app.js
+++ b/src/app.js
@@ -26,7 +26,7 @@ let emailTries = {};
  */
 function configureKafkaConsumer(handlers) {
   // create group consumer
-  const options = { groupId: config.KAFKA_GROUP_ID, connectionString: config.KAFKA_URL };
+  const options = { groupId: config.KAFKA_GROUP_ID, connectionString: config.KAFKA_URL, maxBytes:config.KAFKA_MAXBYTES };
   if (config.KAFKA_CLIENT_CERT && config.KAFKA_CLIENT_CERT_KEY) {
     options.ssl = { cert: config.KAFKA_CLIENT_CERT, key: config.KAFKA_CLIENT_CERT_KEY };
   }


### PR DESCRIPTION
Currently, there is 1 to 1 mapping of kafka topic name and sendgrid template id. 

This changes will allow one Kafka topic can be used for multiple sendgrid templates. Now user can send sendgrid template-id in payload (Kafka-Message). Also can overwrite the existing template-id by sending in payload. 